### PR TITLE
Remove space behind .xpm

### DIFF
--- a/maps/test_FC1.cub
+++ b/maps/test_FC1.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_FC10.cub
+++ b/maps/test_FC10.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_FC11.cub
+++ b/maps/test_FC11.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_FC12.cub
+++ b/maps/test_FC12.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_FC13.cub
+++ b/maps/test_FC13.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_FC2.cub
+++ b/maps/test_FC2.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_FC3.cub
+++ b/maps/test_FC3.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_FC4.cub
+++ b/maps/test_FC4.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_FC5.cub
+++ b/maps/test_FC5.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_FC6.cub
+++ b/maps/test_FC6.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_FC7.cub
+++ b/maps/test_FC7.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_FC8.cub
+++ b/maps/test_FC8.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_FC9.cub
+++ b/maps/test_FC9.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_I1.cub
+++ b/maps/test_I1.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpn

--- a/maps/test_I2.cub
+++ b/maps/test_I2.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 SS ./images/ITEM.xpm

--- a/maps/test_I3.cub
+++ b/maps/test_I3.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_I4.cub
+++ b/maps/test_I4.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 F 00,153,15

--- a/maps/test_I5.cub
+++ b/maps/test_I5.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S 

--- a/maps/test_I6.cub
+++ b/maps/test_I6.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm xpm

--- a/maps/test_I7.cub
+++ b/maps/test_I7.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 s ./images/ITEM.xpm

--- a/maps/test_MAP1.cub
+++ b/maps/test_MAP1.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP10.cub
+++ b/maps/test_MAP10.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP11.cub
+++ b/maps/test_MAP11.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP12.cub
+++ b/maps/test_MAP12.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP13.cub
+++ b/maps/test_MAP13.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP14.cub
+++ b/maps/test_MAP14.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP15.cub
+++ b/maps/test_MAP15.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP16.cub
+++ b/maps/test_MAP16.cub
@@ -14,7 +14,7 @@
 11111111 1111111 111111111111
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP17.cub
+++ b/maps/test_MAP17.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP18.cub
+++ b/maps/test_MAP18.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP19.cub
+++ b/maps/test_MAP19.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 10000000000000000000000000001
 EA ./images/EA.xpm

--- a/maps/test_MAP2.cub
+++ b/maps/test_MAP2.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP20.cub
+++ b/maps/test_MAP20.cub
@@ -1,6 +1,6 @@
 R 640 480 1230
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 11111111 1111111 111111111111
 WE ./images/WE.xpm
 EA ./images/EA.xpm

--- a/maps/test_MAP21.cub
+++ b/maps/test_MAP21.cub
@@ -1,6 +1,6 @@
 R 640 480 
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP22.cub
+++ b/maps/test_MAP22.cub
@@ -1,6 +1,6 @@
 R 640 480 
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP23.cub
+++ b/maps/test_MAP23.cub
@@ -1,6 +1,6 @@
 R 640 480 
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP24.cub
+++ b/maps/test_MAP24.cub
@@ -1,6 +1,6 @@
 R 640 480 
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP25.cub
+++ b/maps/test_MAP25.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP26.cub
+++ b/maps/test_MAP26.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP27.cub
+++ b/maps/test_MAP27.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP28.cub
+++ b/maps/test_MAP28.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP29.cub
+++ b/maps/test_MAP29.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP3.cub
+++ b/maps/test_MAP3.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP30.cub
+++ b/maps/test_MAP30.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP31.cub
+++ b/maps/test_MAP31.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP32.cub
+++ b/maps/test_MAP32.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP33.cub
+++ b/maps/test_MAP33.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP4.cub
+++ b/maps/test_MAP4.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP5.cub
+++ b/maps/test_MAP5.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP6.cub
+++ b/maps/test_MAP6.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP7.cub
+++ b/maps/test_MAP7.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP8.cub
+++ b/maps/test_MAP8.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_MAP9.cub
+++ b/maps/test_MAP9.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_R1.cub
+++ b/maps/test_R1.cub
@@ -1,6 +1,6 @@
 R 640 480 1230
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_R2.cub
+++ b/maps/test_R2.cub
@@ -1,6 +1,6 @@
 R 640
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_R3.cub
+++ b/maps/test_R3.cub
@@ -1,6 +1,6 @@
 R 640 480r
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_R4.cub
+++ b/maps/test_R4.cub
@@ -1,6 +1,6 @@
 r 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_R5.cub
+++ b/maps/test_R5.cub
@@ -1,6 +1,6 @@
 RR 1040 1480 
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_R6.cub
+++ b/maps/test_R6.cub
@@ -1,5 +1,5 @@
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_R7.cub
+++ b/maps/test_R7.cub
@@ -1,7 +1,7 @@
 R 640 480 
 R 640 480 
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_R8.cub
+++ b/maps/test_R8.cub
@@ -1,6 +1,6 @@
 R 
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_W1.cub
+++ b/maps/test_W1.cub
@@ -1,6 +1,6 @@
 R 640 480
 NOO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_W2.cub
+++ b/maps/test_W2.cub
@@ -1,7 +1,7 @@
 R 640 480
 NO ./images/NO.xpm
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_W3.cub
+++ b/maps/test_W3.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm 123
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_W4.cub
+++ b/maps/test_W4.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpn
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_W5.cub
+++ b/maps/test_W5.cub
@@ -1,7 +1,7 @@
 R 640 480
 NO ./images/NO.xpm
 wE ./images/WE.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm
 F 00,153,15

--- a/maps/test_W6.cub
+++ b/maps/test_W6.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm
 F 00,153,15

--- a/maps/test_W7.cub
+++ b/maps/test_W7.cub
@@ -1,7 +1,7 @@
 R 640 480
 NO ./images/NO.xpm
 WE
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm
 F 00,153,15

--- a/maps/test_bonus_map.cub
+++ b/maps/test_bonus_map.cub
@@ -1,6 +1,6 @@
 R 640 480
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 S ./images/ITEM.xpm

--- a/maps/test_valid_map.cub
+++ b/maps/test_valid_map.cub
@@ -1,5 +1,5 @@
 NO ./images/NO.xpm
-SO ./images/SO.xpm 
+SO ./images/SO.xpm
 WE ./images/WE.xpm
 EA ./images/EA.xpm
 R 640 480 


### PR DESCRIPTION
SO ./images/SO.xpm_처럼 .xmp 뒤에 있는 스페이스로 인해, 원래 나와야하는 에러 메세지 전에 다른 에러 메세지가 출력되는 경우가 있어서 지웠습니다.